### PR TITLE
[mod] embeded mozilla observatory

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,4 +9,5 @@ export PATH=/opt/firefox:$PATH
 
 /usr/bin/tor -f /usr/local/searxstats/torrc
 
+pip3 install --upgrade -r requirements-update.txt
 python3 -msearxstats $@

--- a/html/index.html
+++ b/html/index.html
@@ -217,7 +217,8 @@
             <p>Grade from <a href="https://cryptcheck.fr/">cryptcheck.fr</a> (source code: <a href="https://github.com/aeris/cryptcheck">aeris/cryptcheck</a> and <a href="https://github.com/dalf/cryptcheck-backend">dalf/cryptcheck-backend</a>).</p>
 
             <h4 id="help-csp-grade">CSP grade</h4>
-            <p>Grade from <a href="https://observatory.mozilla.org/faq.html">Observatory by mozilla</a>.</p>
+            <p>Grade from <a href="https://github.com/dalf/http-observatory">dalf/http-observatory</a> updated fork of <a href="https://observatory.mozilla.org/faq.html">Observatory by mozilla</a>.
+            <p>Note: The grade shown here might be different from observatory.mozilla.org: searx.space checks the full searx URL, observatory.mozilla.org checks the root path.</p>
 
             <h4 id="help-http-grade">HTTP grade</h4>
             <p>When the page is loaded by Firefox, are the scripts well-known ?</p>

--- a/requirements-update.txt
+++ b/requirements-update.txt
@@ -1,0 +1,1 @@
+httpobs @ git+https://github.com/dalf/http-observatory@master#egg=httpobs

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,9 @@ lxml==4.5.2
 selenium==3.141.0
 pyyaml==5.3.1
 GitPython==3.1.7
+httpobs @ git+https://github.com/dalf/http-observatory@master#egg=httpobs
+requests==2.24.0
+beautifulsoup4==4.6.3
+publicsuffixlist==0.6.2
+psutil==5.4.8
+celery==4.2.1

--- a/searxstats/config.py
+++ b/searxstats/config.py
@@ -1,4 +1,5 @@
 import os
+import hashlib
 
 # Tor
 TOR_HTTP_PROXY = "http://127.0.0.1:9051"
@@ -13,7 +14,7 @@ BROWSER_LOAD_TIMEOUT = 20
 
 # Default headers for all HTTP requests
 DEFAULT_HEADERS = {
-    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:79.0) Gecko/20100101 Firefox/79.0',
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:80.0) Gecko/20100101 Firefox/80.0',
     'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
     'Accept-Language': 'en-US,en;q=0.5',
     'DNT': '1',
@@ -72,14 +73,11 @@ def get_hashes_file_name():
     return os.path.join(CACHE_DIRECTORY, HASHES_FILE_NAME)
 
 
-def get_searx_repository_directory():
-    global CACHE_DIRECTORY, SEARX_GIT_DIRECTORY  # pylint: disable=global-statement
-    return os.path.join(CACHE_DIRECTORY, SEARX_GIT_DIRECTORY)
-
-
-def get_searxinstances_repository_directory():
-    global CACHE_DIRECTORY, SEARXINSTANCES_GIT_DIRECTORY  # pylint: disable=global-statement
-    return os.path.join(CACHE_DIRECTORY, SEARXINSTANCES_GIT_DIRECTORY)
+def get_git_repository_path(url: str) -> str:
+    global CACHE_DIRECTORY  # pylint: disable=global-statement
+    url_hash = hashlib.sha256(url.encode()).hexdigest()
+    name = "git-" + url_hash
+    return os.path.join(CACHE_DIRECTORY, name)
 
 
 def get_geckodriver_file_name():

--- a/searxstats/data/well_kown_hashes.py
+++ b/searxstats/data/well_kown_hashes.py
@@ -3,7 +3,7 @@ import hashlib
 import yaml
 
 import searxstats.common.git_tool as git_tool
-from searxstats.config import get_hashes_file_name, get_searx_repository_directory, SEARX_GIT_REPOSITORY
+from searxstats.config import get_hashes_file_name, get_git_repository_path, SEARX_GIT_REPOSITORY
 
 
 __all__ = ['fetch_file_content_hashes']
@@ -129,5 +129,5 @@ def _fetch_file_content_hashes(cache_file, repo_directory, repo_url):
 
 def fetch_file_content_hashes():
     return _fetch_file_content_hashes(get_hashes_file_name(),
-                                      get_searx_repository_directory(),
+                                      get_git_repository_path(SEARX_GIT_REPOSITORY),
                                       SEARX_GIT_REPOSITORY)

--- a/searxstats/searx_instances.py
+++ b/searxstats/searx_instances.py
@@ -1,11 +1,11 @@
-from searxstats.config import get_searxinstances_repository_directory, SEARXINSTANCES_GIT_REPOSITORY
+from searxstats.config import get_git_repository_path, SEARXINSTANCES_GIT_REPOSITORY
 from searxstats.model import SearxStatisticsResult
 from searxstats.common.git_tool import get_repository
 from searxstats.common.utils import import_module
 
 
 def load_searx_instances() -> dict:
-    repo_directory = get_searxinstances_repository_directory()
+    repo_directory = get_git_repository_path(SEARXINSTANCES_GIT_REPOSITORY)
     get_repository(repo_directory, SEARXINSTANCES_GIT_REPOSITORY)
     model_module = import_module('searxinstances.model', repo_directory)
     return model_module.load()


### PR DESCRIPTION
Currently, searx-stats2 gets the CSP from https://observatory.mozilla.org

* The website allows to scan only the root of the website (not https://.../searx for example)
* The scan sometimes fails because of long waiting time (on searx.space the value is empty)

The project is written in Python: https://github.com/mozilla/http-observatory

This PR adds a dependency to the project (but read until the end).

Some notes:
* there is no release on pypi
* there is a bug on the local scanner (without celery): https://github.com/mozilla/http-observatory/issues/428
* the *.json have not been updated for few months: https://github.com/mozilla/http-observatory/issues/431
* https://github.com/mozilla/http-observatory/issues/394 is fixed (openssl on check.searx.space support TLS1.3).

So, this PR uses a fork:
* https://github.com/dalf/http-observatory/commit/bf343ceb57f362dec1ad18ec22427e3c11b8b3d5 fixes the local scanner
* https://github.com/dalf/http-observatory/commit/1352da5e71cb35e2590f3ce5b00b8673456f20c5 automatically update the static files.

Nothing more, but it still require to keep it up to date.

Before running searx-stats, the package must be updated to make sure to use the last version.
This is done is docker-entrypoint.sh

With this PR, all the HTTP requests come from check.searx.space
