### PR TITLE
[enh] get the searx version from the /config URL

### DIFF
--- a/html/main.js
+++ b/html/main.js
@@ -91,7 +91,7 @@ function normalizeSearxVersion(v) {
     if (typeof (v) !== 'string') {
         return [0, 0, 0, 0, ''];
     }
-    const vdash = v.split('-');
+    const vdash = v.split(/[\-\+]/);
     const vdot = vdash[0].split('.').map((i) => parseInt(i, 10));
     if (vdash.length === 1) {
         return [vdot[0], vdot[1], vdot[2], 0, ''];

--- a/searxstats/common/utils.py
+++ b/searxstats/common/utils.py
@@ -43,6 +43,8 @@ def dict_merge(a, b, path=None):
                 dict_merge(a[key], b[key], path + [str(key)])
             elif a[key] == b[key]:
                 pass  # same leaf value
+            elif isinstance(a[key], list) and isinstance(b[key], list):
+                a[key] = b[key] + a[key]
             else:
                 raise Exception('Conflict at %s' % '.'.join(path + [str(key)]))
         else:


### PR DESCRIPTION
If the /config URL doesn't work, the version is read from the <meta> HTML tag as before.
A comment is added: "Impossible to access https://example.com/config: HTTP status code 404."

Close #33