### PR TITLE
feat: show working engines

### DIFF
--- a/html/main.js
+++ b/html/main.js
@@ -27,6 +27,7 @@ const SORT_CRITERIAS = [
     'http.status_code',
     'error',
     'timing.search.error',
+    'timing.search.working_engines',
     'timing.search_go.error',
     'version',
     'tls.grade',
@@ -240,6 +241,7 @@ const CompareFunctionCriterias = {
     'http.grade': (a, b) => compareTool(a, b, normalizeGrade, 'http', 'grade'),
     'timing.initial.all': (a, b) => -compareTool(a, b, getTime, 'timing', 'initial', 'all'),
     'timing.search.error': (a, b) => -compareTool(a, b, isError, 'timing', 'search'),
+    'timing.search.working_engines': (a, b) => compareTool(a, b, (n) => Math.min(n || 0, 3), 'timing', 'search', 'working_engines'),
     'timing.search_go.error': (a, b) => -compareTool(a, b, isError, 'timing', 'search_go'),
     'timing.search.all': (a, b) => -compareTool(a, b, getTime, 'timing', 'search', 'all'),
     'url': (a, b) => -compareTool(a, b, null, 'url'),
@@ -453,6 +455,16 @@ Vue.component('time-component', {
                 successRate = this.value.success_percentage;
                 if (successRate !== undefined) {
                     tooltip_lines.push(h('p', `${successRate}% success`));
+                }
+                if (this.value.working_engines != null) {
+                    const names = this.value.working_engine_names || [];
+                    const count = this.value.working_engines;
+                    const label = count < 1 ? 'No engines' : `${count} engine${count === 1 ? '' : 's'}`;
+                    const text = names.length ? `${label}: ${names.join(', ')}` : label;
+                    const grade = ['F', 'E', 'D'][count];
+                    tooltip_lines.push(h('p', grade ? {
+                        attrs: { style: `background-color:${hslGrade(grade)}; color:white` },
+                    } : {}, text));
                 }
             }
             if (this.value.error) {

--- a/searxstats/fetcher/timing.py
+++ b/searxstats/fetcher/timing.py
@@ -63,11 +63,20 @@ class CheckResult:
                 continue
             yield result_element, engine_names
 
+    def working_search_engines(self, document):
+        return sorted({
+            name
+            for _result, engine_names in self._iter_meaningful_results(document)
+            for name in engine_names
+            if name and not self.is_wikiengine(name)
+        })
+
     async def check_google_result(self, response):
         return await self._check_html_result_page('google cse', response)
 
     async def check_search_result(self, response):
         document = await html_fromstring(response.text)
+        response.working_engine_names = self.working_search_engines(document)
         message = None
         result_element_list = self.results(document)
         alert_danger_list = self.alert_danger_main(document)
@@ -99,6 +108,7 @@ CHECK_RESULT = CheckResult(
 async def request_stat(client, url, count, between_a, and_b, check_results, **kwargs):
     error_count = 0
     response_time_stats = ResponseTimeStats()
+    working = None
     # loop
     for _ in range(0, count):
         await asyncio.sleep(random.randint(a=between_a, b=and_b))
@@ -111,6 +121,9 @@ async def request_stat(client, url, count, between_a, and_b, check_results, **kw
             await response.aread()
             # check response
             valid_response, error_msg = await check_results(response)
+            names = getattr(response, 'working_engine_names', None)
+            if names is not None:
+                working = names
             if valid_response:
                 response_time_stats.add_response(response)
             else:
@@ -118,7 +131,11 @@ async def request_stat(client, url, count, between_a, and_b, check_results, **kw
                 error_count += 1
                 if error_count > 3:
                     break
-    return response_time_stats.get()
+    result = response_time_stats.get()
+    if working is not None:
+        result['working_engines'] = len(working)
+        result['working_engine_names'] = working
+    return result
 
 
 async def request_stat_with_log(instance, obj, key, *args, **kwargs):


### PR DESCRIPTION
Shows how many good engines (non wiki- with 3+ results min) return results on the default search.

<img width="196" height="131" alt="Screenshot" src="https://github.com/user-attachments/assets/d36862ad-6772-4774-a8fc-0ac27bfdc880" />

<img width="161" height="130" alt="Screenshot" src="https://github.com/user-attachments/assets/6bcfcf2b-b43c-4fdf-9eab-6ae2426d0145" />

- highlighted if it's under 3
- instances with fewer than 3 working engines sort lower
- 3+ are treated as equal as there's diminishing returns and other factors become more important like response time